### PR TITLE
update to CanonicalHostedZoneId v2

### DIFF
--- a/lib/ex_aws/elastic_load_balancing/parsersv2.ex
+++ b/lib/ex_aws/elastic_load_balancing/parsersv2.ex
@@ -117,8 +117,7 @@ if Code.ensure_loaded?(SweetXml) do
         ~x"./DescribeLoadBalancersResult/LoadBalancers/member"l,
         load_balancer_name: ~x"./LoadBalancerName/text()"s,
         dns_name: ~x"./DNSName/text()"s,
-        canonical_hosted_zone_name: ~x"./CanonicalHostedZoneName/text()"s,
-        canonical_hosted_zone_name_id: ~x"./CanonicalHostedZoneNameID/text()"s,
+        canonical_hosted_zone_id: ~x"./CanonicalHostedZoneId/text()"s,
         availability_zones: [
           ~x"./AvailabilityZones/member"l,
           subnet_id: ~x"./SubnetId/text()"s,


### PR DESCRIPTION
This PR is because `canonical_hosted_zone_name` and `canonical_hosted_zone_name_id` were not part of the latest documentation which I found for EBLv2. https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html

My usage case requires the `CanonicalHostedZoneId`, which is not parsed. 

The objective of this PR is to keep in sync with the contract for ELBv2.